### PR TITLE
Correct middleware return type to Function<Promise>.

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -36,7 +36,7 @@ const DEFAULT_MAX_AGE = 1209600;
  *  },
  * });
  *
- * @returns {Promise<Function>} Resolves with exchange middleware.
+ * @returns {Function<Promise>} Resolves with exchange middleware.
  */
 function tokenExchangeHandler({
   authenticateClient,


### PR DESCRIPTION
This is really small PR, just noticed that the jsdoc was slightly off here.