### PR TITLE
Throw error if redirect_uri is provided in client_credentials grant.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,21 +3,6 @@ name: Node.js CI
 on: [push]
 
 jobs:
-  test-node:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    strategy:
-      matrix:
-        node-version: [14.x]
-    steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - run: npm install
-    - name: Run test with Node.js ${{ matrix.node-version }}
-      run: npm run test-node
   lint:
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -33,3 +18,42 @@ jobs:
     - run: npm install
     - name: Run eslint
       run: npm run lint
+  test-node:
+    needs: [lint]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        node-version: [14.x]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm install
+    - name: Run test with Node.js ${{ matrix.node-version }}
+      run: npm run test-node
+  coverage:
+    needs: [test-node]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        node-version: [14.x]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: |
+        npm install
+    - name: Generate coverage report
+      run: |
+        npm run coverage-ci
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v1
+      with:
+        file: ./coverage/lcov.info
+        fail_ci_if_error: true

--- a/lib/main.js
+++ b/lib/main.js
@@ -56,10 +56,11 @@ function tokenExchangeHandler({
         client_id: clientId,
         client_secret: clientSecret,
         grant_type: grantType,
-        scope: scopeRequested
+        scope: scopeRequested,
+        redirect_uri: redirectUri
       } = body;
 
-      _validateParams({clientId, clientSecret, grantType});
+      _validateParams({clientId, clientSecret, grantType, redirectUri});
 
       let client;
       try {
@@ -99,7 +100,7 @@ function tokenExchangeHandler({
   };
 }
 
-function _validateParams({clientId, clientSecret, grantType}) {
+function _validateParams({clientId, clientSecret, grantType, redirectUri}) {
   if(!(clientId && clientSecret)) {
     throw new UnauthorizedClient({
       description: 'Missing client credentials at the Token endpoint.'
@@ -114,6 +115,13 @@ function _validateParams({clientId, clientSecret, grantType}) {
     throw new InvalidGrant({
       error: 'unsupported_grant_type',
       description: `Grant type "${grantType}" is not supported.`
+    });
+  }
+  if(grantType === 'client_credentials' && redirectUri) {
+    throw new InvalidGrant({
+      error: 'unsupported_client_credentials_grant',
+      description: 'Grant type "client_credentials" cannot' +
+        'have "redirectUri" param.'
     });
   }
 }

--- a/lib/main.js
+++ b/lib/main.js
@@ -120,7 +120,7 @@ function _validateParams({clientId, clientSecret, grantType, redirectUri}) {
   if(grantType === 'client_credentials' && redirectUri) {
     throw new InvalidGrant({
       error: 'unsupported_client_credentials_grant',
-      description: 'Grant type "client_credentials" cannot' +
+      description: 'Grant type "client_credentials" cannot ' +
         'have "redirectUri" param.'
     });
   }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
   "scripts": {
     "lint": "eslint .",
     "test": "npm run lint && npm run test-node",
-    "test-node": "cross-env NODE_ENV=test mocha -r esm --preserve-symlinks -t 10000 tests/**/*.spec.js"
+    "test-node": "cross-env NODE_ENV=test mocha -r esm --preserve-symlinks -t 10000 tests/*.spec.js",
+    "coverage": "cross-env NODE_ENV=test nyc --reporter=lcov --reporter=text-summary npm test",
+    "coverage-ci": "cross-env NODE_ENV=test nyc --reporter=lcovonly npm test",
+    "coverage-report": "nyc report"
   },
   "repository": {
     "type": "git",
@@ -40,7 +43,8 @@
     "eslint-config-digitalbazaar": "^2.6.1",
     "eslint-plugin-jsdoc": "^30.2.0",
     "express": "^4.17.1",
-    "mocha": "^8.1.0"
+    "mocha": "^8.1.0",
+    "nyc": "^15.1.0"
   },
   "nyc": {
     "exclude": [


### PR DESCRIPTION
### This is a
- [ ] fix
- [x] feature
- [ ] other

### This PR will:
Throw an error if a redirect_uri param is provided for a grant_type of client_credentials (which does not use that parameter).

### This was tested:
~~This has not been tested yet. I wanted to add some tests here but I am not sure how the middleware returned by the tokenExchangeHandler function will be used.~~

Update: Tests has been added.